### PR TITLE
Database fix

### DIFF
--- a/roles/database/tasks/main.yml
+++ b/roles/database/tasks/main.yml
@@ -15,27 +15,29 @@
     pkg: "{{ item }}"
     state: present
   with_together:
-#    - python-mysqldb # until next release
-    - python-pymysql
-    - python3-pymysql
+    - python3-mysqldb # until next release
+    - python-mysqldb # until next release
+#    - python-pymysql
+#    - python3-pymysql
 
-- import_tasks: secure_installation.yml
+# MariaDB isn't anymore insecure by default
+#- import_tasks: secure_installation.yml
 
 - name: create database
   become: yes
   mysql_db:
     name: '{{ item }}'
     state: present
+    login_unix_socket: /var/run/mysqld/mysqld.sock
   loop: '{{ database_databases }}'
 
 - name: create users
   become: yes
   mysql_user:
-    login_user: root
-    login_password: '{{ database_root_password }}'
     user: '{{ item.user }}'
     password: '{{ item.password }}'
     priv: '{{ item.priv }}'
     state: present
     host: 'localhost'
+    login_unix_socket: /var/run/mysqld/mysqld.sock
   loop: '{{ database_users }}'

--- a/roles/database/tasks/main.yml
+++ b/roles/database/tasks/main.yml
@@ -15,7 +15,7 @@
     pkg: "{{ item }}"
     state: present
   with_together:
-    - python-mysqldb # until next release
+#    - python-mysqldb # until next release
     - python-pymysql
     - python3-pymysql
 

--- a/roles/database/tasks/secure_installation.yml
+++ b/roles/database/tasks/secure_installation.yml
@@ -6,8 +6,8 @@
 - name: change root password
   become: yes
   mysql_user:
+    check_implicit_admin: yes
     login_user: root
-    login_password: ''
     host_all: yes
     user: root
     password: '{{ database_root_password }}'

--- a/roles/database/tasks/secure_installation.yml
+++ b/roles/database/tasks/secure_installation.yml
@@ -10,16 +10,19 @@
     login_user: root
     host_all: yes
     user: root
+    priv: '*.*:ALL'
     password: '{{ database_root_password }}'
     update_password: always
+    login_unix_socket: /var/run/mysqld/mysqld.sock
   ignore_errors: yes
-  register: change_default_root_emtpy
 
 - name: remove anonymous user if it exists
   become: yes
   mysql_user:
+    check_implicit_admin: yes
     login_user: root
     login_password: '{{ database_root_password }}'
+    login_unix_socket: /var/run/mysqld/mysqld.sock
     host_all: yes
     user: ''
     state: absent
@@ -28,6 +31,14 @@
   become: yes
   mysql_db:
     login_user: root
-    login_password: '{{ database_root_password }}'
+    login_password: ''
+    login_unix_socket: /var/run/mysqld/mysqld.sock
     db: test
     state: absent
+
+- name: create ~/.my.cnf configuration
+  become: yes
+  template:
+    src: my.cnf.j2
+    dest: ~/.my.cnf
+    mode: 0600

--- a/roles/database/templates/my.cnf.j2
+++ b/roles/database/templates/my.cnf.j2
@@ -1,0 +1,8 @@
+# {{ ansible_managed }}
+# Configuration for MySQL/MariaDB
+
+[client-server]
+socket=/var/run/mysqld/mysqld.sock
+
+[client]
+password={{ database_root_password }}


### PR DESCRIPTION
Fix issue with the database setup. The installation is now secured through the use of the socket plugin, meaning that only the root user can log in without password from the root shell only. It can be left as is.